### PR TITLE
Update chat input style

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -243,7 +243,7 @@ export default function Home() {
                 type="text"
                 value={newMessage}
                 onChange={(e) => setNewMessage(e.target.value)}
-                className="flex-grow border rounded px-2 py-1 text-black"
+                className="flex-grow border border-white/30 rounded px-2 py-1 bg-white/30 backdrop-blur-sm text-black placeholder-black/70"
                 placeholder="Napíšte správu…"
               />
               <button


### PR DESCRIPTION
## Summary
- make the chat input have a transparent glassy background

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bee8d69148332a98ab86b4ef4a2c8