### PR TITLE
Add Supabase login and register pages

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/lib/supabaseClient';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (!error) {
+      router.push('/home');
+    } else {
+      setError(error.message);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4 max-w-sm mx-auto p-4">
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Email"
+        className="border px-3 py-2 rounded"
+        required
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Password"
+        className="border px-3 py-2 rounded"
+        required
+      />
+      {error && <p className="text-red-600 text-sm">{error}</p>}
+      <button type="submit" className="bg-blue-600 text-white rounded px-4 py-2">
+        Login
+      </button>
+    </form>
+  );
+}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/lib/supabaseClient';
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    const { error } = await supabase.auth.signUp({ email, password });
+    if (!error) {
+      router.push('/home');
+    } else {
+      setError(error.message);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4 max-w-sm mx-auto p-4">
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Email"
+        className="border px-3 py-2 rounded"
+        required
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Password"
+        className="border px-3 py-2 rounded"
+        required
+      />
+      {error && <p className="text-red-600 text-sm">{error}</p>}
+      <button type="submit" className="bg-blue-600 text-white rounded px-4 py-2">
+        Register
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- create `/login` and `/register` pages
- build simple forms that call Supabase auth
- redirect to `/home` after success

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686cd9f7d12483329c0901514e9422b9