### PR TITLE
Implement auth wrapper and navbar

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState, useCallback, type FormEvent } from "react"
 import io from "socket.io-client";
 import SimplePeer, { SignalData } from "simple-peer";
 import { MdSend, MdSwipe, MdNavigateNext, MdOutlineLocalPolice } from "react-icons/md";
+import requireAuth from "@/lib/requireAuth";
 
 type MatchPayload = { otherId: string; initiator: boolean };
 
@@ -16,7 +17,7 @@ const ICE_SERVERS = [
   },
 ];
 
-export default function Home() {
+function ChatPage() {
   const localVideoRef = useRef<HTMLVideoElement>(null);
   const remoteVideoRef = useRef<HTMLVideoElement>(null);
   const localStreamRef = useRef<MediaStream | null>(null);
@@ -294,3 +295,6 @@ export default function Home() {
     </div>
   );
 }
+
+export default requireAuth(ChatPage);
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Providers from "./providers";
+import NavBar from "@/components/NavBar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,6 +30,7 @@ export default function RootLayout({
         <body
           className={`${geistSans.variable} ${geistMono.variable} antialiased`}
         >
+          <NavBar />
           {children}
         </body>
       </html>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -4,8 +4,9 @@ import { useEffect, useState } from 'react';
 import type { User } from "@supabase/supabase-js";
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabaseClient';
+import requireAuth from '@/lib/requireAuth';
 
-export default function ProfilePage() {
+function ProfilePage() {
   const router = useRouter();
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
@@ -42,3 +43,6 @@ export default function ProfilePage() {
     </div>
   );
 }
+
+export default requireAuth(ProfilePage);
+

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabaseClient'
+
+export default function NavBar() {
+  const router = useRouter()
+
+  async function handleLogout() {
+    await supabase.auth.signOut()
+    router.push('/')
+  }
+
+  return (
+    <nav className="flex gap-4 p-4 border-b">
+      <Link href="/">Home</Link>
+      <Link href="/chat">Chat</Link>
+      <Link href="/profile">Profile</Link>
+      <button onClick={handleLogout} className="text-red-600">Log out</button>
+    </nav>
+  )
+}

--- a/src/lib/requireAuth.tsx
+++ b/src/lib/requireAuth.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+import { useUser, useSessionContext } from '@supabase/auth-helpers-react'
+
+export default function requireAuth<P>(Component: React.ComponentType<P>) {
+  return function RequireAuth(props: P) {
+    const router = useRouter()
+    const { isLoading } = useSessionContext()
+    const user = useUser()
+
+    useEffect(() => {
+      if (!isLoading && !user) {
+        router.push('/login')
+      }
+    }, [isLoading, user, router])
+
+    if (!user) {
+      return null
+    }
+
+    return <Component {...props} />
+  }
+}


### PR DESCRIPTION
## Summary
- add `requireAuth` helper to enforce login on client components
- wrap Chat and Profile pages with the auth helper
- create `NavBar` component with links
- display the navbar from the root layout

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686cde9ddbcc8332b40a7458de520afd