### PR TITLE
Display loading message in requireAuth

### DIFF
--- a/src/lib/requireAuth.tsx
+++ b/src/lib/requireAuth.tsx
@@ -16,6 +16,10 @@ export default function requireAuth<P>(Component: React.ComponentType<P>) {
       }
     }, [isLoading, user, router])
 
+    if (isLoading) {
+      return <p className="p-4">Loading...</p>
+    }
+
     if (!user) {
       return null
     }


### PR DESCRIPTION
## Summary
- show a simple loading message while authentication is still loading

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686cfbf42104833284b6c8b7ee05c8c8