### PR TITLE
Add online count broadcasting

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,33 @@
 'use client';
 
 import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
+import io from 'socket.io-client';
 
 export default function Home() {
+  const [online, setOnline] = useState<number | null>(null);
+  const socketRef = useRef<ReturnType<typeof io> | null>(null);
+
+  useEffect(() => {
+    const socket = io({ path: '/api/socket' });
+    socketRef.current = socket;
+
+    const handleCount = (count: number) => setOnline(count);
+    socket.on('online-count', handleCount);
+
+    return () => {
+      socket.off('online-count', handleCount);
+      socket.disconnect();
+    };
+  }, []);
+
   return (
     <main className="flex flex-col md:flex-row min-h-screen p-4 gap-8 items-center justify-center">
       <div className="flex flex-col items-center justify-center flex-1 gap-4">
         <h1 className="text-4xl font-bold">Lumia</h1>
-        <div className="text-sm text-gray-500">Live online users: --</div>
+        <div className="text-sm text-gray-500">
+          Live online users: {online ?? '--'}
+        </div>
       </div>
       <div className="flex flex-col items-center justify-center flex-1 gap-4">
         <Link href="/chat" className="bg-blue-600 text-white rounded px-4 py-2">

--- a/src/pages/api/socket.ts
+++ b/src/pages/api/socket.ts
@@ -28,8 +28,11 @@ export default function handler(
   const pairs = new Map<string, string>();
   const reports = new Map<string, number>();
   const REPORT_THRESHOLD = 3;
+  let onlineCount = 0;
 
   io.on("connection", (socket) => {
+    onlineCount++;
+    io.emit("online-count", onlineCount);
     console.log("🆕 spojenie:", socket.id);
 
     if ((reports.get(socket.id) ?? 0) >= REPORT_THRESHOLD) {
@@ -81,6 +84,8 @@ export default function handler(
       }
 
       console.log("❌ odpojenie:", socket.id);
+      onlineCount--;
+      io.emit("online-count", onlineCount);
     });
   });
 


### PR DESCRIPTION
## Summary
- track active socket count on the server
- broadcast `online-count` events to all clients
- show online user count on the home page

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686d096179608332a96df3264821b336