### PR TITLE
Fix requireAuth generic type error and use next/image

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import type { User } from '@supabase/supabase-js';
 import { useRouter } from 'next/navigation';
+import Image from 'next/image';
 import { supabase, fetchMyProfile, type Profile } from '@/lib/supabaseClient';
 import requireAuth from '@/lib/requireAuth';
 
@@ -38,9 +39,11 @@ function ProfilePage() {
   return (
     <div className="flex flex-col gap-4 p-4">
       <h1 className="text-2xl font-bold">Profile</h1>
-      <img
+      <Image
         src={profile.avatar_url ?? ''}
         alt="Avatar"
+        width={128}
+        height={128}
         className="w-32 h-32 object-cover rounded-full border"
       />
       <p>Email: {user.email}</p>

--- a/src/lib/requireAuth.tsx
+++ b/src/lib/requireAuth.tsx
@@ -4,7 +4,9 @@ import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
 import { useUser, useSessionContext } from '@supabase/auth-helpers-react'
 
-export default function requireAuth<P>(Component: React.ComponentType<P>) {
+export default function requireAuth<P extends JSX.IntrinsicAttributes>(
+  Component: React.ComponentType<P>
+) {
   return function RequireAuth(props: P) {
     const router = useRouter()
     const { isLoading } = useSessionContext()


### PR DESCRIPTION
## Summary
- constrain generic for `requireAuth` to fix React call signature error
- swap `<img>` for `<Image>` in profile page

## Testing
- `npm run lint`
- `NEXT_DISABLE_FONT_DOWNLOADS=1 npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_686d0fda99b88332ab58068ae10971e3