### PR TITLE
Fix profile fetch when no row exists

### DIFF
--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -23,7 +23,7 @@ export async function fetchMyProfile(): Promise<Profile | null> {
       'id, avatar_url, nickname, birthdate, gender, location'
     )
     .eq('id', user.id)
-    .single();
+    .maybeSingle();
 
   if (error) {
     console.error('Error loading profile', error);


### PR DESCRIPTION
## Summary
- prevent Supabase error when a user's profile row is missing

## Testing
- `npm ci`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686d1117bbd48332895e9298f3bcc1f3