### PR TITLE
Switch to createPagesBrowserClient for Supabase

### DIFF
--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,6 +1,6 @@
-import { createBrowserSupabaseClient } from '@supabase/auth-helpers-nextjs';
+import { createPagesBrowserClient } from '@supabase/auth-helpers-nextjs';
 
-export const supabase = createBrowserSupabaseClient();
+export const supabase = createPagesBrowserClient();
 
 export interface Profile {
   id: string;


### PR DESCRIPTION
## Summary
- use `createPagesBrowserClient` instead of deprecated `createBrowserSupabaseClient`

## Testing
- `npm run lint`
- `npm run build` *(fails: failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_686d13649efc833295022d0d551697b6