### PR TITLE
Enhance profile editing and registration forms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@supabase/auth-helpers-nextjs": "^0.10.0",
         "@supabase/auth-helpers-react": "^0.5.0",
         "@supabase/supabase-js": "^2.50.3",
+        "emoji-flags": "^1.3.0",
         "next": "15.3.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -2132,6 +2133,15 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+      "integrity": "sha512-q5i8bFLg2wDfsuR56c1NzlJFPzVD+9mxhDrhqOGigEFa87OZHlF+9dWeGWzVTP/0ECiA/JUGzfzRr2t3eYORRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2586,6 +2596,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -2629,6 +2648,16 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/columnify": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.1.tgz",
+      "integrity": "sha512-JUsujUm6cRwWegK9l8WK4ykTAyqLYzzuJN82TTxxgGyDpSgjdx0Mzs9tWGaU8UIDupVt70dbzqUGBxYtNOOTUw==",
+      "license": "MIT",
+      "dependencies": {
+        "strip-ansi": "^2.0.1",
+        "wcwidth": "^1.0.0"
       }
     },
     "node_modules/concat-map": {
@@ -2767,6 +2796,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -2839,6 +2880,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/emoji-flags": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/emoji-flags/-/emoji-flags-1.3.0.tgz",
+      "integrity": "sha512-cw6zdVlLPtFhpTurp9AM7c6+dBeCQAu0PrGpUQ9lA1XWsWW9lNEEbnAF9gtf8acb4jTSpUTOFZ1hHsBdSTQZGg==",
+      "license": "MIT",
+      "dependencies": {
+        "columnify": "1.5.1",
+        "lodash.find": "3.2.1"
+      },
+      "bin": {
+        "emoji-flags": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/emoji-regex": {
@@ -4903,12 +4960,120 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash._basecallback": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
+      "integrity": "sha512-LQffghuO63ufDY33KKO1ezGKbcFZK3ngYV7JpxaUomoM5acf0YeXU3Pm8csVE0girVs50TXzfNibl69Co3ggJA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._baseisequal": "^3.0.0",
+        "lodash._bindcallback": "^3.0.0",
+        "lodash.isarray": "^3.0.0",
+        "lodash.pairs": "^3.0.0"
+      }
+    },
+    "node_modules/lodash._baseeach": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
+      "integrity": "sha512-IqUZ9MQo2UT1XPGuBntInqTOlc+oV+bCo0kMp+yuKGsfvRSNgUW0YjWVZUrG/gs+8z/Eyuc0jkJjOBESt9BXxg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "node_modules/lodash._basefind": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basefind/-/lodash._basefind-3.0.0.tgz",
+      "integrity": "sha512-OCYxW9f0nMWjRaJyvGxrM/x/xGZTIYEiz+PyFux4YIZr7DtXLQpmCc6aDJdhPA1vnnsrY+N7BvS76hAdlnGHfg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash._basefindindex": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/lodash._basefindindex/-/lodash._basefindindex-3.6.0.tgz",
+      "integrity": "sha512-Ay3Ok74tVwGB79L5lVZlVgpGYjV9ty8DEVPxIUhgGGkqrqk6I+BPJ5kUIxd5S1b2Qg03VXtdg/Dpv2zcwQReoA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash._baseisequal": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
+      "integrity": "sha512-U+3GsNEZj9ebI03ncLC2pLmYVjgtYZEwdkAPO7UGgtGvAz36JVFPAQUufpSaVL93Cz5arc6JGRKZRhaOhyVJYA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.isarray": "^3.0.0",
+        "lodash.istypedarray": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "node_modules/lodash._bindcallback": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "integrity": "sha512-2wlI0JRAGX8WEf4Gm1p/mv/SZ+jLijpj0jyaE/AXeuQphzCgD8ZQW4oSpoN8JAopujOFGU3KMuq7qfHBWlGpjQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha512-RrL9VxMEPyDMHOd9uFbvMe8X55X16/cGM5IgOKgRElQZutpX89iS6vwl64duTV1/16w5JY7tuFNXqoekmh1EmA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.find": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-3.2.1.tgz",
+      "integrity": "sha512-pN4ZB4KEepNd/97vLC5F3rl1tAAa5uWvISru2psLyLA8BtqBQwOA+2D7fdusG0aGmElOEurbSMlKI3UxjqoLQg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basecallback": "^3.0.0",
+        "lodash._baseeach": "^3.0.0",
+        "lodash._basefind": "^3.0.0",
+        "lodash._basefindindex": "^3.0.0",
+        "lodash.isarray": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha512-JwObCrNJuT0Nnbuecmqr5DgtuBppuCvGD9lxjFpAzwnVtdGoDQ1zig+5W8k5/6Gcn0gZ3936HDAlGd28i7sOGQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.istypedarray": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+      "integrity": "sha512-lGWJ6N8AA3KSv+ZZxlTdn4f6A7kMfpJboeyvbFdE7IU9YAgweODqmOgdUHOA+c6lVWeVLysdaxciFXi+foVsWw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha512-CuBsapFjcubOGMn3VD+24HOAPxM79tH+V6ivJL3CHYjtrawauDJHUk//Yew9Hvc6e9rbCrURGk8z6PC+8WJBfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.pairs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
+      "integrity": "sha512-lgXvpU43ZNQrZ/pK2cR97YzKeAno3e3HhcyvLKsofljeHKrQcZhT1vW7fg4X61c92tM+mjD/DypoLZYuAKNIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.keys": "^3.0.0"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -6321,6 +6486,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/strip-ansi": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+      "integrity": "sha512-2h8q2CP3EeOhDJ+jd932PRMpa3/pOJFGoF22J1U/DNbEK2gSW2DqeF46VjCXsSQXhC+k/l8/gaaRBQKL6hUPfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^1.0.0"
+      },
+      "bin": {
+        "strip-ansi": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -6712,6 +6892,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/auth-helpers-react": "^0.5.0",
     "@supabase/supabase-js": "^2.50.3",
+    "emoji-flags": "^1.3.0",
     "next": "15.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,17 +1,23 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, FormEvent } from 'react';
 import type { User } from '@supabase/supabase-js';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { supabase, fetchMyProfile, type Profile } from '@/lib/supabaseClient';
 import requireAuth from '@/lib/requireAuth';
+import flags from 'emoji-flags';
 
 function ProfilePage() {
   const router = useRouter();
   const [user, setUser] = useState<User | null>(null);
   const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(true);
+  const [editing, setEditing] = useState(false);
+  const [newNickname, setNewNickname] = useState('');
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   useEffect(() => {
     async function loadData() {
@@ -20,6 +26,7 @@ function ProfilePage() {
         setUser(data.user);
         const prof = await fetchMyProfile();
         setProfile(prof);
+        if (prof) setNewNickname(prof.nickname ?? '');
       }
       setLoading(false);
     }
@@ -31,10 +38,51 @@ function ProfilePage() {
     router.push('/');
   }
 
+  async function handleSave(e: FormEvent) {
+    e.preventDefault();
+    if (!profile || !user) return;
+    setSaving(true);
+    setErrorMsg(null);
+
+    let avatar_url = profile.avatar_url;
+    if (avatarFile) {
+      const { data: uploadData, error: uploadError } = await supabase.storage
+        .from('avatars')
+        .upload(`public/${user.id}`, avatarFile, { upsert: true });
+      if (uploadError) {
+        setErrorMsg(uploadError.message);
+        setSaving(false);
+        return;
+      }
+      avatar_url = supabase.storage
+        .from('avatars')
+        .getPublicUrl(uploadData.path).data.publicUrl;
+    }
+
+    const { error } = await supabase
+      .from('profiles')
+      .update({ avatar_url, nickname: newNickname })
+      .eq('id', user.id);
+    if (error) {
+      setErrorMsg(error.message);
+      setSaving(false);
+      return;
+    }
+    setProfile({ ...profile, avatar_url, nickname: newNickname });
+    setEditing(false);
+    setAvatarFile(null);
+    setSaving(false);
+  }
+
   if (loading) return <p className="p-4">Loading...</p>;
   if (!user) return <p className="p-4">No user found.</p>;
   if (!profile)
     return <p className="p-4">No profile information available.</p>;
+
+  const country = profile.location ? flags.countryCode(profile.location) : null;
+  const locationText = country
+    ? `${country.emoji} ${country.name}`
+    : profile.location ?? '-';
 
   return (
     <div className="flex flex-col gap-4 p-4">
@@ -47,16 +95,65 @@ function ProfilePage() {
         className="w-32 h-32 object-cover rounded-full border"
       />
       <p>Email: {user.email}</p>
-      <p>Nickname: {profile.nickname ?? '-'}</p>
-      <p>Birthdate: {profile.birthdate ?? '-'}</p>
-      <p>Gender: {profile.gender ?? '-'}</p>
-      <p>Location: {profile.location ?? '-'}</p>
-      <button
-        onClick={handleSignOut}
-        className="bg-red-600 text-white rounded px-4 py-2 w-fit"
-      >
-        Sign Out
-      </button>
+      {editing ? (
+        <form onSubmit={handleSave} className="flex flex-col gap-2">
+          <input
+            type="text"
+            value={newNickname}
+            onChange={(e) => setNewNickname(e.target.value)}
+            className="border px-3 py-2 rounded"
+          />
+          <input
+            type="file"
+            accept="image/*"
+            onChange={(e) =>
+              setAvatarFile(e.target.files ? e.target.files[0] : null)
+            }
+            className="border px-3 py-2 rounded"
+          />
+          {errorMsg && <p className="text-red-600 text-sm">{errorMsg}</p>}
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              disabled={saving}
+              className="bg-green-600 text-white rounded px-4 py-2"
+            >
+              Save
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setEditing(false);
+                setAvatarFile(null);
+              }}
+              className="bg-gray-300 rounded px-4 py-2"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      ) : (
+        <>
+          <p>Nickname: {profile.nickname ?? '-'}</p>
+          <p>Birthdate: {profile.birthdate ?? '-'}</p>
+          <p>Gender: {profile.gender ?? '-'}</p>
+          <p>Location: {locationText}</p>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setEditing(true)}
+              className="bg-blue-600 text-white rounded px-4 py-2 w-fit"
+            >
+              Edit Profile
+            </button>
+            <button
+              onClick={handleSignOut}
+              className="bg-red-600 text-white rounded px-4 py-2 w-fit"
+            >
+              Sign Out
+            </button>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -3,6 +3,7 @@
 import { useState, FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabaseClient';
+import flags from 'emoji-flags';
 
 export default function RegisterPage() {
   const router = useRouter();
@@ -107,22 +108,30 @@ export default function RegisterPage() {
         className="border px-3 py-2 rounded"
         required
       />
-      <input
-        type="text"
+      <select
         value={gender}
         onChange={(e) => setGender(e.target.value)}
-        placeholder="Gender"
         className="border px-3 py-2 rounded"
         required
-      />
-      <input
-        type="text"
+      >
+        <option value="">Select Gender</option>
+        <option value="Male">Male</option>
+        <option value="Female">Female</option>
+        <option value="Other">Other</option>
+      </select>
+      <select
         value={location}
         onChange={(e) => setLocation(e.target.value)}
-        placeholder="Location"
         className="border px-3 py-2 rounded"
         required
-      />
+      >
+        <option value="">Select Country</option>
+        {flags.data.map((c: { code: string; emoji: string; name: string }) => (
+          <option key={c.code} value={c.code}>
+            {c.emoji} {c.name}
+          </option>
+        ))}
+      </select>
       <input
         type="file"
         accept="image/*"

--- a/src/lib/requireAuth.tsx
+++ b/src/lib/requireAuth.tsx
@@ -1,11 +1,12 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { useEffect } from 'react'
+import React, { useEffect, ComponentType } from 'react'
+import type { JSX } from 'react'
 import { useUser, useSessionContext } from '@supabase/auth-helpers-react'
 
 export default function requireAuth<P extends JSX.IntrinsicAttributes>(
-  Component: React.ComponentType<P>
+  Component: ComponentType<P>
 ) {
   return function RequireAuth(props: P) {
     const router = useRouter()

--- a/src/types/emoji-flags.d.ts
+++ b/src/types/emoji-flags.d.ts
@@ -1,0 +1,16 @@
+declare module 'emoji-flags' {
+  interface Country {
+    code: string;
+    emoji: string;
+    unicode: string;
+    name: string;
+    title: string;
+    dialCode: string;
+  }
+
+  const flags: {
+    countryCode(code: string): Country | undefined;
+    data: Country[];
+  };
+  export default flags;
+}


### PR DESCRIPTION
## Summary
- allow editing nickname and profile picture
- show location with flag display
- gender and location pickers on register page
- add emoji-flags dependency and types
- update auth HOC generics

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json`
- `npm run build` *(fails: Failed to fetch font `Geist` from `fonts.googleapis.com`)*

------
https://chatgpt.com/codex/tasks/task_e_686d19280d048332a57cb263f96ff06e