### PR TITLE
Add global background gradient animation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,20 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+@keyframes blob-move-1 {
+  0%, 100% { transform: translate(-20%, -10%) scale(1); }
+  50% { transform: translate(-10%, 10%) scale(1.1); }
+}
+@keyframes blob-move-2 {
+  0%, 100% { transform: translate(10%, 20%) scale(1); }
+  50% { transform: translate(20%, -20%) scale(1.1); }
+}
+@keyframes blob-move-3 {
+  0%, 100% { transform: translate(0%, 0%) scale(1); }
+  50% { transform: translate(-20%, 20%) scale(1.05); }
+}
+@layer utilities {
+  .animate-blob-1 { animation: blob-move-1 18s ease-in-out infinite; }
+  .animate-blob-2 { animation: blob-move-2 22s ease-in-out infinite; }
+  .animate-blob-3 { animation: blob-move-3 20s ease-in-out infinite; }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Providers from "./providers";
 import NavBar from "@/components/NavBar";
+import BackgroundGradientAnimation from "@/components/BackgroundGradientAnimation";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,9 +29,10 @@ export default function RootLayout({
     <Providers>
       <html lang="en">
         <body
-          className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+          className={`${geistSans.variable} ${geistMono.variable} antialiased relative overflow-hidden`}
         >
           <NavBar />
+          <BackgroundGradientAnimation />
           {children}
         </body>
       </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useEffect, useRef, useState } from 'react';
 import io from 'socket.io-client';
+import BackgroundGradientAnimation from '@/components/BackgroundGradientAnimation';
 
 export default function Home() {
   const [online, setOnline] = useState<number | null>(null);
@@ -24,7 +25,8 @@ export default function Home() {
   //new
 
   return (
-    <main className="flex flex-col md:flex-row min-h-screen p-4 gap-8 items-center justify-center">
+    <main className="flex flex-col md:flex-row min-h-screen p-4 gap-8 items-center justify-center relative overflow-hidden">
+      <BackgroundGradientAnimation />
       <div className="flex flex-col items-center justify-center flex-1 gap-4">
         <h1 className="text-4xl font-bold">Lumia</h1>
         <div className="text-sm text-gray-500">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,6 @@
 import Link from 'next/link';
 import { useEffect, useRef, useState } from 'react';
 import io from 'socket.io-client';
-import BackgroundGradientAnimation from '@/components/BackgroundGradientAnimation';
 
 export default function Home() {
   const [online, setOnline] = useState<number | null>(null);
@@ -26,7 +25,6 @@ export default function Home() {
 
   return (
     <main className="flex flex-col md:flex-row min-h-screen p-4 gap-8 items-center justify-center relative overflow-hidden">
-      <BackgroundGradientAnimation />
       <div className="flex flex-col items-center justify-center flex-1 gap-4">
         <h1 className="text-4xl font-bold">Lumia</h1>
         <div className="text-sm text-gray-500">

--- a/src/components/BackgroundGradientAnimation.tsx
+++ b/src/components/BackgroundGradientAnimation.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+export default function BackgroundGradientAnimation() {
+  return (
+    <div className="absolute inset-0 -z-10 overflow-hidden pointer-events-none">
+      <div className="absolute left-1/2 top-0 w-[60vw] h-[60vw] -translate-x-1/2 bg-gradient-to-tr from-pink-500 via-red-500 to-yellow-500 rounded-full blur-3xl opacity-50 mix-blend-multiply animate-blob-1" />
+      <div className="absolute left-0 bottom-0 w-[60vw] h-[60vw] bg-gradient-to-tr from-blue-500 via-cyan-500 to-purple-500 rounded-full blur-3xl opacity-50 mix-blend-multiply animate-blob-2" />
+      <div className="absolute right-0 top-1/4 w-[60vw] h-[60vw] bg-gradient-to-tr from-green-500 via-lime-500 to-emerald-500 rounded-full blur-3xl opacity-50 mix-blend-multiply animate-blob-3" />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- import `BackgroundGradientAnimation` into the root layout
- include the animation behind all pages and mark `<body>` relative
- remove local animation usage from the home page

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Google fonts)*

------
https://chatgpt.com/codex/tasks/task_e_686d6609d438833285b4a11ba89094e3