### PR TITLE
Fix profile upload permissions

### DIFF
--- a/supabase/create_profiles_table.sql
+++ b/supabase/create_profiles_table.sql
@@ -6,3 +6,22 @@ create table if not exists profiles (
   gender text,
   location text
 );
+
+alter table profiles enable row level security;
+
+create policy "Allow profile owner insert" on profiles
+  for insert with check (auth.uid() = id);
+
+create policy "Allow profile owner select" on profiles
+  for select using (auth.uid() = id);
+
+create policy "Allow profile owner update" on profiles
+  for update using (auth.uid() = id);
+
+create policy "Avatar uploads" on storage.objects
+  for insert with check (
+    bucket_id = 'avatars' and auth.role() = 'authenticated'
+  );
+
+create policy "Avatar read" on storage.objects
+  for select using (bucket_id = 'avatars');


### PR DESCRIPTION
## Summary
- add row level security policies for profiles table
- allow avatar uploads to the `avatars` bucket

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e12fcebd883328b41724ab5f351f1