### PR TITLE
Fix RLS violation when uploading avatars

### DIFF
--- a/supabase/create_profiles_table.sql
+++ b/supabase/create_profiles_table.sql
@@ -23,5 +23,12 @@ create policy "Avatar uploads" on storage.objects
     bucket_id = 'avatars' and auth.role() = 'authenticated'
   );
 
+create policy "Avatar updates" on storage.objects
+  for update using (
+    bucket_id = 'avatars' and auth.uid() = owner
+  ) with check (
+    bucket_id = 'avatars' and auth.uid() = owner
+  );
+
 create policy "Avatar read" on storage.objects
   for select using (bucket_id = 'avatars');


### PR DESCRIPTION
## Summary
- allow updating avatar files in Supabase storage

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686e143fcad883328f56344b49c6d9b1