### PR TITLE
Apply glass effect to home page buttons

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from 'react';
 import io from 'socket.io-client';
 //import { AuroraBackground } from '@/components/ui/aurora-background'; // uprav cestu podľa svojej štruktúry
 import { Vortex } from '@/components/ui/vortex';   // ← nový import
+import { glassClasses, cn } from '@/lib/utils';
 
 export default function Home() {
   const [online, setOnline] = useState<number | null>(null);
@@ -44,13 +45,14 @@ export default function Home() {
       </div>
 
       <div className="flex flex-col items-center justify-center flex-1 gap-4">
-        <Link href="/chat" className="bg-blue-600 text-white rounded px-4 py-2">
+        <Link href="/chat" className={cn(glassClasses, 'px-4 py-2')}
+        >
           Start Videochat
         </Link>
-        <button className="bg-gray-200/40 backdrop-blur rounded px-4 py-2">
+        <button className={cn(glassClasses, 'px-4 py-2')}>
           Select Country
         </button>
-        <button className="bg-gray-200/40 backdrop-blur rounded px-4 py-2">
+        <button className={cn(glassClasses, 'px-4 py-2')}>
           Select Gender
         </button>
       </div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,7 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/** Shared glass style used across components */
+export const glassClasses =
+  "overflow-hidden rounded-[28px] drop-shadow-[-8px_-12px_46px_rgba(0,0,0,0.37)] bg-white/30 dark:bg-zinc-900/30 backdrop-brightness-110 backdrop-blur-[2px] backdrop-[url('#displacementFilter')] drop-shadow-[0_4px_16px_rgba(0,0,0,0.25)] before:absolute before:inset-0 before:rounded-[inherit] before:pointer-events-none before:content-[''] before:ring-1 before:ring-white/60 before:shadow-[inset_0_0_4px_rgba(255,255,255,0.28)] after:absolute after:inset-0 after:rounded-[inherit] after:pointer-events-none after:content-[''] after:bg-[radial-gradient(60%_60%_at_0%_0%,rgba(255,255,255,0.75)_0%,rgba(255,255,255,0.15)_18%,transparent_35%),radial-gradient(60%_60%_at_100%_100%,rgba(255,255,255,0.35)_0%,rgba(255,255,255,0.1)_18%,transparent_35%)] after:bg-no-repeat text-white";


### PR DESCRIPTION
## Summary
- export glass effect styles from `utils.ts`
- use glass effect for home page buttons

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_686e26d42fc4833280bb56d351703e0a