### PR TITLE
Implement glass-style select elements

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import io from 'socket.io-client';
 //import { AuroraBackground } from '@/components/ui/aurora-background'; // uprav cestu podľa svojej štruktúry
 import { Vortex } from '@/components/ui/vortex';   // ← nový import
 import { glassClasses, cn } from '@/lib/utils';
+import GlassSelect from '@/components/GlassSelect';
 import { countries } from '@/lib/countries';
 
 export default function Home() {
@@ -54,10 +55,10 @@ export default function Home() {
         >
           Start Videochat
         </Link>
-        <select
+        <GlassSelect
           value={country}
           onChange={(e) => setCountry(e.target.value)}
-          className={cn(glassClasses, 'px-4 py-2 text-black')}
+          className="text-white"
         >
           <option value="" disabled>
             Select Country
@@ -65,11 +66,11 @@ export default function Home() {
           {countries.map(({ code, name, flag }) => (
             <option key={code} value={name}>{`${flag} ${name}`}</option>
           ))}
-        </select>
-        <select
+        </GlassSelect>
+        <GlassSelect
           value={gender}
           onChange={(e) => setGender(e.target.value)}
-          className={cn(glassClasses, 'px-4 py-2 text-black')}
+          className="text-white"
         >
           <option value="" disabled>
             Select Gender
@@ -77,7 +78,7 @@ export default function Home() {
           <option value="Male">Male</option>
           <option value="Female">Female</option>
           <option value="Other">Other</option>
-        </select>
+        </GlassSelect>
       </div>
       {/* --------------------------------------- */}
     </Vortex>

--- a/src/components/GlassSelect.tsx
+++ b/src/components/GlassSelect.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { cn, glassClasses } from '@/lib/utils'
+import type { SelectHTMLAttributes } from 'react'
+
+interface GlassSelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
+  containerClassName?: string
+}
+
+export default function GlassSelect({
+  containerClassName,
+  className,
+  children,
+  ...props
+}: GlassSelectProps) {
+  return (
+    <div className={cn('relative', containerClassName)}>
+      <select
+        {...props}
+        className={cn(
+          glassClasses,
+          'px-4 py-2 pr-8 appearance-none bg-transparent text-white',
+          className,
+        )}
+      >
+        {children}
+      </select>
+      <div className="pointer-events-none absolute inset-y-0 right-3 flex items-center">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className="w-4 h-4"
+        >
+          <path d="M7 10l5 5 5-5H7z" />
+        </svg>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- style `country` and `gender` selects with a new reusable `GlassSelect` component
- use the new component on the home page so dropdowns match the glass button style

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_686e2a9f46808332b3287c43288c67b1