### PR TITLE
Ensure Twemoji parses dynamic DOM content

### DIFF
--- a/src/components/TwemojiInit.tsx
+++ b/src/components/TwemojiInit.tsx
@@ -5,11 +5,27 @@ import twemoji from "twemoji";
 
 export default function TwemojiInit() {
   useEffect(() => {
-    twemoji.parse(document.body, {
+    const config = {
       base: "/twemoji/",
       folder: "svg",
       ext: ".svg",
+    } as const;
+
+    const parse = () => twemoji.parse(document.body, config);
+    parse();
+
+    const observer = new MutationObserver((mutations) => {
+      for (const m of mutations) {
+        m.addedNodes.forEach((node) => {
+          if (node.nodeType === 1) {
+            twemoji.parse(node as HTMLElement, config);
+          }
+        });
+      }
     });
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    return () => observer.disconnect();
   }, []);
   return null;
 }

--- a/src/components/ui/BlurModal.tsx
+++ b/src/components/ui/BlurModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { ReactNode, useEffect, useState } from "react";
+import React, { ReactNode, useEffect, useState, useRef } from "react";
+import twemoji from "twemoji";
 import { createPortal } from "react-dom";
 
 interface BlurModalProps {
@@ -18,11 +19,22 @@ export default function BlurModal({
   children,
 }: BlurModalProps) {
   const [mounted, setMounted] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
 
   // Ensure the modal is rendered only after the component is mounted
   useEffect(() => {
     setMounted(true);
   }, []);
+
+  useEffect(() => {
+    if (open && ref.current) {
+      twemoji.parse(ref.current, {
+        base: "/twemoji/",
+        folder: "svg",
+        ext: ".svg",
+      });
+    }
+  }, [open]);
 
   if (!mounted || !open) return null;
 
@@ -39,7 +51,7 @@ export default function BlurModal({
       className="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm flex items-center justify-center"
       onClick={handleOverlayClick}
     >
-      <div className="bg-white/20 text-white border border-white/30 rounded-2xl p-4">
+      <div ref={ref} className="bg-white/20 text-white border border-white/30 rounded-2xl p-4">
         {children}
       </div>
     </div>,


### PR DESCRIPTION
## Summary
- observe DOM changes with MutationObserver and parse new nodes via Twemoji
- parse Twemoji inside `BlurModal` when the modal opens

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e4e89999c8332993f3ff2363f4af4