### PR TITLE
Persist Vortex effect across main pages

### DIFF
--- a/src/app/(with-bg)/layout.tsx
+++ b/src/app/(with-bg)/layout.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { Vortex } from '@/components/ui/vortex';
+
+export default function WithBgLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <Vortex
+      className="min-h-screen"
+      containerClassName="bg-transparent"
+      particleCount={700}
+      baseHue={220}
+      backgroundColor="#000"
+    >
+      {children}
+    </Vortex>
+  );
+}

--- a/src/app/(with-bg)/page.tsx
+++ b/src/app/(with-bg)/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { useEffect, useRef, useState } from 'react';
 import io from 'socket.io-client';
 //import { AuroraBackground } from '@/components/ui/aurora-background'; // uprav cestu podľa svojej štruktúry
-import { Vortex } from '@/components/ui/vortex';   // ← nový import
+// Background effect provided by layout
 import { glassClasses, cn, iconButtonClasses } from '@/lib/utils';
 import { countries } from '@/lib/countries';
 import BlurModal from '@/components/ui/BlurModal';
@@ -34,24 +34,14 @@ export default function Home() {
 
   return (
     <>
-    <Vortex
-      /* Tailwind trieda Vortexu, v ktorej držíš layout */
-      className="flex flex-col md:flex-row min-h-screen p-4 gap-8 items-center justify-center"
-      /* Tailwind trieda pre absolútny div s canvasom (voliteľné) */
-      containerClassName="bg-transparent"
-      /* príklady vlastných props – prispôsob podľa seba */
-      particleCount={700}
-      baseHue={220}          // východzia farba (modro-fialová)
-      //rangeHue={100}         // rozsah odtieňov
-      backgroundColor="#000" // farba pozadia, ak nechceš, nechaj default
-    >
-      {/* ----- tvoj pôvodný obsah stránky ----- */}
-      <div className="flex flex-col items-center justify-center flex-1 gap-4">
-        <h1 className="text-4xl font-bold">Lumia</h1>
-        <div className="text-sm text-gray-300">
-          Live online users: {online ?? '--'}
+      <div className="flex flex-col md:flex-row min-h-screen p-4 gap-8 items-center justify-center">
+        {/* ----- tvoj pôvodný obsah stránky ----- */}
+        <div className="flex flex-col items-center justify-center flex-1 gap-4">
+          <h1 className="text-4xl font-bold">Lumia</h1>
+          <div className="text-sm text-gray-300">
+            Live online users: {online ?? '--'}
+          </div>
         </div>
-      </div>
 
       <div className="flex flex-col items-center justify-center flex-1 gap-4">
         <Link
@@ -78,9 +68,9 @@ export default function Home() {
             {gender === 'Male' ? '♂️' : gender === 'Female' ? '♀️' : gender === 'Other' ? '⚧' : <MdOutlineWc />}
           </button>
         </div>
+        </div>
+        {/* --------------------------------------- */}
       </div>
-      {/* --------------------------------------- */}
-    </Vortex>
     <BlurModal open={countryOpen} onClose={() => setCountryOpen(false)}>
       <div className="flex flex-col gap-2 max-h-60 overflow-y-auto">
         {countries.map(({ code, name, flag }) => (

--- a/src/app/(with-bg)/profile/edit/page.tsx
+++ b/src/app/(with-bg)/profile/edit/page.tsx
@@ -11,7 +11,6 @@ import {
 } from '@/lib/supabaseClient';
 import { countries } from '@/lib/countries';
 import requireAuth from '@/lib/requireAuth';
-import { Vortex } from '@/components/ui/vortex';
 import { glassClasses, cn } from '@/lib/utils';
 
 function EditProfilePage() {
@@ -83,13 +82,7 @@ function EditProfilePage() {
   if (!profile) return <p className="p-4">No profile found.</p>;
 
   return (
-    <Vortex
-      className="min-h-screen flex items-center justify-center"
-      containerClassName="bg-transparent"
-      particleCount={700}
-      baseHue={220}
-      backgroundColor="#000"
-    >
+    <div className="min-h-screen flex items-center justify-center">
       <div className={cn(glassClasses, 'p-4 max-w-md w-full')}>
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           <div className="flex flex-col items-center gap-2">
@@ -156,7 +149,7 @@ function EditProfilePage() {
           </button>
         </form>
       </div>
-    </Vortex>
+    </div>
   );
 }
 

--- a/src/app/(with-bg)/profile/page.tsx
+++ b/src/app/(with-bg)/profile/page.tsx
@@ -7,7 +7,6 @@ import Image from 'next/image';
 import { supabase, fetchMyProfile, type Profile } from '@/lib/supabaseClient';
 import { countries } from '@/lib/countries';
 import requireAuth from '@/lib/requireAuth';
-import { Vortex } from '@/components/ui/vortex';
 import { glassClasses, cn } from '@/lib/utils';
 
 function ProfilePage() {
@@ -44,19 +43,13 @@ function ProfilePage() {
     : null;
 
   return (
-    <Vortex
-      className="min-h-screen flex items-center justify-center"
-      containerClassName="bg-transparent"
-      particleCount={700}
-      baseHue={220}
-      backgroundColor="#000"
-    >
+    <div className="min-h-screen flex items-center justify-center">
       <div className={cn(glassClasses, 'p-4 max-w-md w-full flex flex-col gap-4')}>
-      <h1 className="text-2xl font-bold">Profile</h1>
-      {profile.avatar_url && (
-        <Image
-          src={profile.avatar_url}
-          alt="Avatar"
+        <h1 className="text-2xl font-bold">Profile</h1>
+        {profile.avatar_url && (
+          <Image
+            src={profile.avatar_url}
+            alt="Avatar"
           width={128}
           height={128}
           className="w-32 h-32 object-cover rounded-full border"
@@ -87,7 +80,7 @@ function ProfilePage() {
         Sign Out
       </button>
       </div>
-    </Vortex>
+    </div>
   );
 }
 

--- a/src/app/(with-bg)/shop/page.tsx
+++ b/src/app/(with-bg)/shop/page.tsx
@@ -1,21 +1,14 @@
 'use client';
 
-import { Vortex } from '@/components/ui/vortex';
 import { glassClasses, cn } from '@/lib/utils';
 
 export default function ShopPage() {
   return (
-    <Vortex
-      className="min-h-screen flex items-center justify-center"
-      containerClassName="bg-transparent"
-      particleCount={700}
-      baseHue={220}
-      backgroundColor="#000"
-    >
+    <div className="min-h-screen flex items-center justify-center">
       <div className={cn(glassClasses, 'p-4 max-w-md w-full text-center')}>
         <h1 className="text-xl font-bold">Shop</h1>
         <p>Placeholder page.</p>
       </div>
-    </Vortex>
+    </div>
   );
 }

--- a/src/app/(with-bg)/spravy/page.tsx
+++ b/src/app/(with-bg)/spravy/page.tsx
@@ -1,21 +1,14 @@
 'use client';
 
-import { Vortex } from '@/components/ui/vortex';
 import { glassClasses, cn } from '@/lib/utils';
 
 export default function SpravyPage() {
   return (
-    <Vortex
-      className="min-h-screen flex items-center justify-center"
-      containerClassName="bg-transparent"
-      particleCount={700}
-      baseHue={220}
-      backgroundColor="#000"
-    >
+    <div className="min-h-screen flex items-center justify-center">
       <div className={cn(glassClasses, 'p-4 max-w-md w-full text-center')}>
         <h1 className="text-xl font-bold">Spravy</h1>
         <p>Placeholder page.</p>
       </div>
-    </Vortex>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `(with-bg)` route group layout using `Vortex` effect
- move homepage, profile, spravy and shop under the new layout
- adjust pages to remove their individual `Vortex` wrappers

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e891d282c83328b95ab9c59176160