### PR TITLE
Add glass style to Lumia heading

### DIFF
--- a/src/app/(with-bg)/page.tsx
+++ b/src/app/(with-bg)/page.tsx
@@ -37,7 +37,9 @@ export default function Home() {
       <div className="flex flex-col md:flex-row min-h-screen p-4 gap-8 items-center justify-center">
         {/* ----- tvoj pôvodný obsah stránky ----- */}
         <div className="flex flex-col items-center justify-center flex-1 gap-4">
-          <h1 className="text-4xl font-bold">Lumia</h1>
+          <div className={cn(glassClasses, 'px-4 py-2 text-center')}>
+            <h1 className="text-4xl font-bold">Lumia</h1>
+          </div>
           <div className="text-sm text-gray-300">
             Live online users: {online ?? '--'}
           </div>


### PR DESCRIPTION
## Summary
- use shared `glassClasses` for the Lumia heading on the home page

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e8b1d39e083329c45ca812914c9c0