### PR TITLE
Dynamic particle count based on live users

### DIFF
--- a/src/app/(with-bg)/layout.tsx
+++ b/src/app/(with-bg)/layout.tsx
@@ -1,13 +1,34 @@
 'use client';
 
 import { Vortex } from '@/components/ui/vortex';
+import io from 'socket.io-client';
+import { useEffect, useRef, useState } from 'react';
 
 export default function WithBgLayout({ children }: { children: React.ReactNode }) {
+  const [particleCount, setParticleCount] = useState(700);
+  const socketRef = useRef<ReturnType<typeof io> | null>(null);
+
+  useEffect(() => {
+    const socket = io({ path: '/api/socket' });
+    socketRef.current = socket;
+
+    const handleCount = (count: number) => {
+      setParticleCount(count < 50 ? 700 : count);
+    };
+
+    socket.on('online-count', handleCount);
+
+    return () => {
+      socket.off('online-count', handleCount);
+      socket.disconnect();
+    };
+  }, []);
+
   return (
     <Vortex
       className="min-h-screen"
       containerClassName="bg-transparent"
-      particleCount={700}
+      particleCount={particleCount}
       baseHue={220}
       backgroundColor="#000"
     >


### PR DESCRIPTION
## Summary
- make `(with-bg)/layout.tsx` connect to socket
- update particle count dynamically according to live user count
- keep minimum particle count of 700 when fewer than 50 users are online

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686e8ed9a560833297a5f7379337243c