### PR TITLE
Implement game mode switch with icon

### DIFF
--- a/src/app/(with-bg)/page.tsx
+++ b/src/app/(with-bg)/page.tsx
@@ -14,6 +14,7 @@ import {
   MdSportsEsports,
   MdPlaylistAddCheck,
 } from 'react-icons/md';
+import IconSwitch from '@/components/ui/IconSwitch';
 
 const gameTitles = [
   'Truth or Dare',
@@ -89,13 +90,12 @@ export default function Home() {
           </button>
         </div>
         <div>
-          <button
-            onClick={() => setGameMode((g) => !g)}
-            aria-label="Toggle Game Mode"
-            className={cn(glassClasses, iconButtonClasses, gameMode && 'bg-white/40')}
-          >
-            <MdSportsEsports />
-          </button>
+          <IconSwitch
+            checked={gameMode}
+            onChange={setGameMode}
+            icon={<MdSportsEsports className="text-xs" />}
+            className={cn(glassClasses)}
+          />
         </div>
         <div className="relative">
           <button

--- a/src/components/ui/IconSwitch.tsx
+++ b/src/components/ui/IconSwitch.tsx
@@ -1,0 +1,42 @@
+import { cn } from '@/lib/utils';
+import React from 'react';
+
+interface IconSwitchProps {
+  /** Whether the switch is on */
+  checked: boolean;
+  /** Callback when the switch changes */
+  onChange: (checked: boolean) => void;
+  /** Icon shown inside the switch knob */
+  icon: React.ReactNode;
+  className?: string;
+}
+
+export default function IconSwitch({
+  checked,
+  onChange,
+  icon,
+  className,
+}: IconSwitchProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+      className={cn(
+        'relative inline-flex h-6 w-12 items-center rounded-full transition-colors',
+        checked ? 'bg-blue-600' : 'bg-gray-400',
+        className,
+      )}
+    >
+      <span
+        className={cn(
+          'absolute left-1 top-1 h-4 w-4 rounded-full bg-white text-black flex items-center justify-center transition-transform',
+          checked ? 'translate-x-6' : 'translate-x-0',
+        )}
+      >
+        {icon}
+      </span>
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable `IconSwitch` component
- use `IconSwitch` on the home page for game mode toggle

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686fc83ff35083328ad45366033d112a