### PR TITLE
Remove LUMIA banner from chat panel

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -278,11 +278,6 @@ function ChatPage() {
 
         {/* action panel */}
         <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-10 flex items-center gap-3 md:flex-col md:gap-2 bg-white/20 backdrop-blur-md border border-white/30 text-white px-4 py-2 rounded-2xl">
-          <span className="font-semibold flex gap-1">
-            {Array.from('LUMIA').map((letter) => (
-              <span key={letter} className="px-1">{letter}</span>
-            ))}
-          </span>
           {!started ? (
             <button
               onClick={handleStart}


### PR DESCRIPTION
## Summary
- remove decorative LUMIA `<span>` block from the chat action panel

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fe953e89883329cd144a6a4241cda