### PR TITLE
Enable swipe gesture on chat videos

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -54,6 +54,9 @@ function ChatPage() {
   const [panelVisible, setPanelVisible] = useState(true);
   const hideTimer = useRef<NodeJS.Timeout | null>(null);
 
+  const touchStartY = useRef<number | null>(null);
+  const touchEndY = useRef<number | null>(null);
+
   const searchParams = useSearchParams();
   const filterCountry = searchParams?.get("country") || "";
   const filterGender  = searchParams?.get("gender")  || "";
@@ -217,6 +220,27 @@ function ChatPage() {
     setHasReported(true);
   }
 
+  function handleTouchStart(e: React.TouchEvent<HTMLDivElement>) {
+    touchStartY.current = e.touches[0].clientY;
+  }
+
+  function handleTouchEnd(e: React.TouchEvent<HTMLDivElement>) {
+    touchEndY.current = e.changedTouches[0].clientY;
+    if (
+      touchStartY.current !== null &&
+      touchEndY.current !== null &&
+      touchStartY.current - touchEndY.current > 50
+    ) {
+      e.preventDefault();
+      nextPartner();
+    } else {
+      e.preventDefault();
+      showPanel();
+    }
+    touchStartY.current = null;
+    touchEndY.current = null;
+  }
+
   function sendMessage(e: FormEvent) {
     e.preventDefault();
     const msg = newMessage.trim();
@@ -232,6 +256,8 @@ function ChatPage() {
       <div
         className="relative flex flex-col md:flex-row flex-1"
         onClick={() => showPanel()}
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
       >
         {/* partner video */}
         <div className="flex-1 relative bg-black overflow-hidden">


### PR DESCRIPTION
## Summary
- use refs to track touch start and end positions
- switch partners when swiping up on the videos
- show panel on simple tap

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686feaf12bf0833284f973a090c385f7