### PR TITLE
Automate next chat session after disconnect

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -213,12 +213,7 @@ function ChatPage() {
     });
 
     socket.on("partner-left", () => {
-      setStatus("Partner odišiel.");
-      setNextEnabled(true);
-      setPartnerId(null);
-      setHasReported(false);
-      setMessages([]);
-      peerRef.current?.destroy();
+      nextPartner();
     });
 
     socket.on("signal", (data: SignalData) =>


### PR DESCRIPTION
## Summary
- automatically start a new chat session when a partner disconnects

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870bc37f1a88332bfdecd3a1fb3efa3