### PR TITLE
Update chat interface

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -14,9 +14,10 @@ import {
   MdSwipe,
   MdNavigateNext,
   MdOutlineLocalPolice,
+  MdStop,
 } from "react-icons/md";
 import requireAuth from "@/lib/requireAuth";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { AnimatePresence, motion, Transition,  } from "framer-motion";
 
 /* ──────────────────────────────────────────────── */
@@ -178,6 +179,8 @@ function ChatPage() {
   const searchParams = useSearchParams();
   const filterCountry = searchParams?.get("country") || "";
   const filterGender = searchParams?.get("gender") || "";
+
+  const router = useRouter();
 
   /* ─────── TikTok scroll: pole kariet ─────── */
   const [cards, setCards] = useState<Card[]>([
@@ -358,6 +361,12 @@ function nextPartner() {
   setCards([{ id: Date.now(), stage: "waiting" }]);
 }
 
+  function handleStop() {
+    cleanupFull();
+    setStarted(false);
+    router.push('/');
+  }
+
   function reportPartner() {
     if (!partnerId || !socketRef.current) return;
     socketRef.current.emit("report-user", partnerId);
@@ -477,6 +486,13 @@ function nextPartner() {
               className="px-4 py-2 md:px-3 md:py-2 bg-orange-400 md:bg-orange-600 rounded-lg md:rounded disabled:opacity-50"
             >
               <MdOutlineLocalPolice />
+            </button>
+            <button
+              onClick={handleStop}
+              aria-label="Ukončiť"
+              className="px-4 py-2 md:px-3 md:py-2 bg-blue-500 md:bg-blue-600 rounded-lg md:rounded"
+            >
+              <MdStop />
             </button>
           </div>
         )}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -16,6 +16,10 @@ export default function NavBar() {
   const router = useRouter()
   const pathname = usePathname()
 
+  if (pathname.startsWith('/chat')) {
+    return null
+  }
+
   async function handleLogout() {
     await supabase.auth.signOut()
     router.push('/')


### PR DESCRIPTION
## Summary
- hide the navigation bar while on the chat page
- add a new stop button to exit chat and return home

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870c3cfd85c83329bcf06b99b4aadc7