### PR TITLE
Add count flag to socket connections

### DIFF
--- a/src/app/(with-bg)/layout.tsx
+++ b/src/app/(with-bg)/layout.tsx
@@ -9,7 +9,7 @@ export default function WithBgLayout({ children }: { children: React.ReactNode }
   const socketRef = useRef<ReturnType<typeof io> | null>(null);
 
   useEffect(() => {
-    const socket = io({ path: '/api/socket' });
+    const socket = io({ path: '/api/socket', query: { purpose: 'count' } });
     socketRef.current = socket;
 
     const handleCount = (count: number) => {

--- a/src/app/(with-bg)/page.tsx
+++ b/src/app/(with-bg)/page.tsx
@@ -35,7 +35,7 @@ export default function Home() {
   const [selectedGames, setSelectedGames] = useState<string[]>([]);
 
   useEffect(() => {
-    const socket = io({ path: '/api/socket' });
+    const socket = io({ path: '/api/socket', query: { purpose: 'count' } });
     socketRef.current = socket;
 
     const handleCount = (count: number) => setOnline(count);

--- a/src/pages/api/socket.ts
+++ b/src/pages/api/socket.ts
@@ -49,6 +49,16 @@ export default function handler(
     io.emit("online-count", onlineCount);
     console.log("🆕 spojenie:", socket.id);
 
+    const purpose = socket.handshake.query.purpose;
+    if (purpose === 'count') {
+      socket.on('disconnect', () => {
+        console.log("❌ odpojenie:", socket.id);
+        onlineCount--;
+        io.emit("online-count", onlineCount);
+      });
+      return;
+    }
+
     try {
       const { data, error } = await supabase
         .from("user_reports")


### PR DESCRIPTION
## Summary
- track online user count separately from chat pairing
- initialize non-chat sockets with `purpose: 'count'`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870c6d56144833297e306877979ab5d