### PR TITLE
Implement shared online count context

### DIFF
--- a/src/app/(with-bg)/layout.tsx
+++ b/src/app/(with-bg)/layout.tsx
@@ -1,28 +1,11 @@
 'use client';
 
 import { Vortex } from '@/components/ui/vortex';
-import io from 'socket.io-client';
-import { useEffect, useRef, useState } from 'react';
+import { OnlineCountProvider, useOnlineCount } from '@/lib/onlineCountContext';
 
-export default function WithBgLayout({ children }: { children: React.ReactNode }) {
-  const [particleCount, setParticleCount] = useState(700);
-  const socketRef = useRef<ReturnType<typeof io> | null>(null);
-
-  useEffect(() => {
-    const socket = io({ path: '/api/socket', query: { purpose: 'count' } });
-    socketRef.current = socket;
-
-    const handleCount = (count: number) => {
-      setParticleCount(count < 4 ? 700 : count);
-    };
-
-    socket.on('online-count', handleCount);
-
-    return () => {
-      socket.off('online-count', handleCount);
-      socket.disconnect();
-    };
-  }, []);
+function LayoutContent({ children }: { children: React.ReactNode }) {
+  const count = useOnlineCount();
+  const particleCount = count !== null && count >= 4 ? count : 700;
 
   return (
     <Vortex
@@ -34,5 +17,13 @@ export default function WithBgLayout({ children }: { children: React.ReactNode }
     >
       {children}
     </Vortex>
+  );
+}
+
+export default function WithBgLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <OnlineCountProvider>
+      <LayoutContent>{children}</LayoutContent>
+    </OnlineCountProvider>
   );
 }

--- a/src/app/(with-bg)/page.tsx
+++ b/src/app/(with-bg)/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useRef, useState } from 'react';
-import io from 'socket.io-client';
+import { useState } from 'react';
+import { useOnlineCount } from '@/lib/onlineCountContext';
 //import { AuroraBackground } from '@/components/ui/aurora-background'; // uprav cestu podľa svojej štruktúry
 // Background effect provided by layout
 import { glassClasses, cn, iconButtonClasses } from '@/lib/utils';
@@ -24,8 +24,7 @@ const gameTitles = [
 ];
 
 export default function Home() {
-  const [online, setOnline] = useState<number | null>(null);
-  const socketRef = useRef<ReturnType<typeof io> | null>(null);
+  const online = useOnlineCount();
   const [country, setCountry] = useState('');
   const [gender, setGender] = useState('');
   const [countryOpen, setCountryOpen] = useState(false);
@@ -33,19 +32,6 @@ export default function Home() {
   const [gameMode, setGameMode] = useState(false);
   const [gamesOpen, setGamesOpen] = useState(false);
   const [selectedGames, setSelectedGames] = useState<string[]>([]);
-
-  useEffect(() => {
-    const socket = io({ path: '/api/socket', query: { purpose: 'count' } });
-    socketRef.current = socket;
-
-    const handleCount = (count: number) => setOnline(count);
-    socket.on('online-count', handleCount);
-
-    return () => {
-      socket.off('online-count', handleCount);
-      socket.disconnect();
-    };
-  }, []);
 
   return (
     <>

--- a/src/lib/onlineCountContext.tsx
+++ b/src/lib/onlineCountContext.tsx
@@ -1,0 +1,31 @@
+import { createContext, useContext, useEffect, useRef, useState } from 'react';
+import io from 'socket.io-client';
+
+/** Context storing number of currently online users */
+export const OnlineCountContext = createContext<number | null>(null);
+
+export function OnlineCountProvider({ children }: { children: React.ReactNode }) {
+  const [count, setCount] = useState<number | null>(null);
+  const socketRef = useRef<ReturnType<typeof io> | null>(null);
+
+  useEffect(() => {
+    const socket = io({ path: '/api/socket', query: { purpose: 'count' } });
+    socketRef.current = socket;
+
+    const handleCount = (value: number) => setCount(value);
+    socket.on('online-count', handleCount);
+
+    return () => {
+      socket.off('online-count', handleCount);
+      socket.disconnect();
+    };
+  }, []);
+
+  return (
+    <OnlineCountContext.Provider value={count}>{children}</OnlineCountContext.Provider>
+  );
+}
+
+export function useOnlineCount() {
+  return useContext(OnlineCountContext);
+}


### PR DESCRIPTION
## Summary
- add `OnlineCountProvider` context in `src/lib`
- use online count from context in `(with-bg)` layout
- display count from context on the home page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870c9f117108332b8b092101be3b1ac