### PR TITLE
Fix overlay message not disappearing

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -77,9 +77,11 @@ function SessionCard({
           className="w-full h-full object-cover"
         />
 
-        <div className="absolute inset-0 flex items-center justify-center text-white text-sm bg-black/30 pointer-events-none">
-          {stage === "waiting" ? "Čakám na partnera…" : status}
-        </div>
+        {(stage === "waiting" || status) && (
+          <div className="absolute inset-0 flex items-center justify-center text-white text-sm bg-black/30 pointer-events-none">
+            {stage === "waiting" ? "Čakám na partnera…" : status}
+          </div>
+        )}
       </div>
 
       {/* tvoje video */}
@@ -161,6 +163,14 @@ function ChatPage() {
     []
   );
   const [newMessage, setNewMessage] = useState("");
+
+  // hide connection message after showing it
+  useEffect(() => {
+    if (status === "Video pripojené 🎉") {
+      const t = setTimeout(() => setStatus(""), 2000);
+      return () => clearTimeout(t);
+    }
+  }, [status]);
 
   /* action-panel auto-hide */
   const [panelVisible, setPanelVisible] = useState(true);


### PR DESCRIPTION
## Summary
- hide "Video pripojené" overlay after a short delay
- don't render the overlay panel when no status text is present

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870cb9eadc48332be78e580c675fba1