### PR TITLE
Adjust video orientation for desktop

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -68,7 +68,7 @@ function SessionCard({
   setNewMessage: (v: string) => void;
 }) {
   return (
-    <div className="relative flex flex-col h-full w-full">
+    <div className="relative flex flex-col lg:flex-row h-full w-full">
       {/* partner video alebo waiting */}
       <div className="flex-1 relative bg-black overflow-hidden">
         <video


### PR DESCRIPTION
## Summary
- update chat layout so the video streams are stacked vertically on mobile and side-by-side on larger screens

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870da80e65c83329a093c3b06da2d34